### PR TITLE
imx6ul-var-som: Add wifi to model string

### DIFF
--- a/arch/arm/boot/dts/imx6ul-imx6ull-var-som-wm8731.dtsi
+++ b/arch/arm/boot/dts/imx6ul-imx6ull-var-som-wm8731.dtsi
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Variscite Ltd. - http://www.variscite.com
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/ {
+	sound {
+		compatible = "fsl,imx-audio-wm8731";
+		model = "wm8731-audio";
+		cpu-dai = <&sai2>;
+		audio-codec = <&codec>;
+		audio-routing =
+			"Headphone Jack",	"LHPOUT",
+			"Headphone Jack",	"RHPOUT",
+			"LLINEIN",		"Line Jack",
+			"RLINEIN",		"Line Jack";
+	};
+};
+ 
+&i2c2 {
+	codec: wm8731@1a {
+		compatible = "wlf,wm8731";
+		reg = <0x1a>;
+		clocks = <&clks IMX6UL_CLK_SAI2>;
+		clock-names = "mclk";
+	};
+};
+

--- a/arch/arm/boot/dts/imx6ul-imx6ull-var-som-wm8904.dtsi
+++ b/arch/arm/boot/dts/imx6ul-imx6ull-var-som-wm8904.dtsi
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Variscite Ltd. - http://www.variscite.com
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/ {
+	sound {
+		compatible = "simple-audio-card";
+		simple-audio-card,name = "wm8904audio";
+		simple-audio-card,widgets =
+			"Microphone", "Microphone Jack",
+			"Headphone", "Headphone Jack",
+			"Line", "Line In Jack";
+		simple-audio-card,routing =
+			"Headphone Jack", "HPOUTL",
+			"Headphone Jack", "HPOUTR",
+			"IN2L", "Line In Jack",
+			"IN2R", "Line In Jack",
+			"IN1L", "Microphone Jack",
+			"IN1R", "Microphone Jack";
+		simple-audio-card,mclk-fs = <256>;
+		simple-audio-card,format = "i2s";
+		simple-audio-card,bitclock-master = <&sound_master>;
+		simple-audio-card,frame-master = <&sound_master>;
+
+		simple-audio-card,cpu {
+			sound-dai = <&sai2>;
+			system-clock-direction = "in";
+		};
+
+		sound_master: simple-audio-card,codec {
+			sound-dai = <&codec>;
+			system-clock-type = "wm8904,mclk";
+			system-clock-frequency = <12288000>;
+			system-clock-direction = "out";
+		};
+	};
+};
+
+&i2c2 {
+	codec: wm8904@1a {
+		compatible = "wlf,wm8904";
+		#sound-dai-cells = <0>;
+		reg = <0x1a>;
+		clocks = <&clks IMX6UL_CLK_SAI2>;
+		clock-names = "mclk";
+		status = "okay";
+	};
+};
+
+&sai2 {
+	#sound-dai-cells = <0>;
+};

--- a/arch/arm/boot/dts/imx6ul-var-som-5g-emmc_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-5g-emmc_wifi-wm8731.dts
@@ -12,7 +12,7 @@
 #define PHY
 /* #define  NAND */
 #include "imx6ul-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8731.dtsi"
 
 / {
         model = "Variscite i.MX6 UL VAR-SOM-5G eMMC + WM8731 + WIFI";

--- a/arch/arm/boot/dts/imx6ul-var-som-5g-emmc_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-5g-emmc_wifi-wm8731.dts
@@ -15,5 +15,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
 
 / {
-        model = "Variscite i.MX6 UL VAR-SOM-5G eMMC + WM8731";
+        model = "Variscite i.MX6 UL VAR-SOM-5G eMMC + WM8731 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ul-var-som-5g-emmc_wifi.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-5g-emmc_wifi.dts
@@ -12,7 +12,7 @@
 #define PHY
 /* #define  NAND */
 #include "imx6ul-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8904.dtsi"
 
 / {
         model = "Variscite i.MX6 UL VAR-SOM-5G eMMC + WM8904 + WIFI";

--- a/arch/arm/boot/dts/imx6ul-var-som-5g-emmc_wifi.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-5g-emmc_wifi.dts
@@ -15,5 +15,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
 
 / {
-        model = "Variscite i.MX6 UL VAR-SOM-5G eMMC + WM8904";
+        model = "Variscite i.MX6 UL VAR-SOM-5G eMMC + WM8904 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ul-var-som-5g-nand_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-5g-nand_wifi-wm8731.dts
@@ -12,7 +12,7 @@
 #define  NAND
 #define PHY
 #include "imx6ul-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8731.dtsi"
 
 / {
         model = "Variscite i.MX6 UL VAR-SOM-5G NAND + WM8731 + WIFI";

--- a/arch/arm/boot/dts/imx6ul-var-som-5g-nand_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-5g-nand_wifi-wm8731.dts
@@ -15,5 +15,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
 
 / {
-        model = "Variscite i.MX6 UL VAR-SOM-5G NAND + WM8731";
+        model = "Variscite i.MX6 UL VAR-SOM-5G NAND + WM8731 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ul-var-som-5g-nand_wifi.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-5g-nand_wifi.dts
@@ -15,5 +15,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
 
 / {
-        model = "Variscite i.MX6 UL VAR-SOM-5G NAND + WM8904";
+        model = "Variscite i.MX6 UL VAR-SOM-5G NAND + WM8904 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ul-var-som-5g-nand_wifi.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-5g-nand_wifi.dts
@@ -12,7 +12,7 @@
 #define  NAND
 #define PHY
 #include "imx6ul-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8904.dtsi"
 
 / {
         model = "Variscite i.MX6 UL VAR-SOM-5G NAND + WM8904 + WIFI";

--- a/arch/arm/boot/dts/imx6ul-var-som-emmc_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-emmc_wifi-wm8731.dts
@@ -11,7 +11,7 @@
 #define PHY
 /* #define  NAND */
 #include "imx6ul-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8731.dtsi"
 
 / {
         model = "Variscite i.MX6 UL VAR-SOM eMMC + WM8731 + WIFI";

--- a/arch/arm/boot/dts/imx6ul-var-som-emmc_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-emmc_wifi-wm8731.dts
@@ -14,5 +14,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
 
 / {
-        model = "Variscite i.MX6 UL VAR-SOM eMMC + WM8731";
+        model = "Variscite i.MX6 UL VAR-SOM eMMC + WM8731 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ul-var-som-emmc_wifi.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-emmc_wifi.dts
@@ -14,5 +14,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
 
 / {
-        model = "Variscite i.MX6 UL VAR-SOM eMMC + WM8904";
+        model = "Variscite i.MX6 UL VAR-SOM eMMC + WM8904 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ul-var-som-emmc_wifi.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-emmc_wifi.dts
@@ -11,7 +11,7 @@
 #define PHY
 /* #define  NAND */
 #include "imx6ul-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8904.dtsi"
 
 / {
         model = "Variscite i.MX6 UL VAR-SOM eMMC + WM8904 + WIFI";

--- a/arch/arm/boot/dts/imx6ul-var-som-nand_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-nand_wifi-wm8731.dts
@@ -15,5 +15,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
 
 / {
-        model = "Variscite i.MX6 UL VAR-SOM NAND + WM8731";
+        model = "Variscite i.MX6 UL VAR-SOM NAND + WM8731 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ul-var-som-nand_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-nand_wifi-wm8731.dts
@@ -12,7 +12,7 @@
 #define PHY
 #include "imx6ul-var-som.dtsi"
 
-#include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8731.dtsi"
 
 / {
         model = "Variscite i.MX6 UL VAR-SOM NAND + WM8731 + WIFI";

--- a/arch/arm/boot/dts/imx6ul-var-som-nand_wifi.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-nand_wifi.dts
@@ -12,7 +12,7 @@
 #define PHY
 #include "imx6ul-var-som.dtsi"
 
-#include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8904.dtsi"
 
 / {
         model = "Variscite i.MX6 UL VAR-SOM NAND + WM8904 + WIFI";

--- a/arch/arm/boot/dts/imx6ul-var-som-nand_wifi.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-nand_wifi.dts
@@ -15,5 +15,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
 
 / {
-        model = "Variscite i.MX6 UL VAR-SOM NAND + WM8904";
+        model = "Variscite i.MX6 UL VAR-SOM NAND + WM8904 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ul-var-som-sd_emmc-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-sd_emmc-wm8731.dts
@@ -11,7 +11,7 @@
 /* #define  NAND */
 #define PHY
 #include "imx6ul-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8731.dtsi"
 
 / {
         model = "Variscite i.MX6 UL VAR-SOM SDCARD/eMMC + WM8731";

--- a/arch/arm/boot/dts/imx6ul-var-som-sd_emmc.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-sd_emmc.dts
@@ -11,7 +11,7 @@
 /* #define  NAND */
 #define PHY
 #include "imx6ul-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8904.dtsi"
 
 / {
         model = "Variscite i.MX6 UL VAR-SOM SDCARD/eMMC + WM8904";

--- a/arch/arm/boot/dts/imx6ul-var-som-sd_nand-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-sd_nand-wm8731.dts
@@ -11,7 +11,7 @@
 #define  NAND
 #define PHY
 #include "imx6ul-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8731.dtsi"
 
 / {
         model = "Variscite i.MX6 UL VAR-SOM SDCARD/NAND + WM8731";

--- a/arch/arm/boot/dts/imx6ul-var-som-sd_nand.dts
+++ b/arch/arm/boot/dts/imx6ul-var-som-sd_nand.dts
@@ -11,7 +11,7 @@
 #define  NAND
 #define PHY
 #include "imx6ul-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8904.dtsi"
 
 / {
         model = "Variscite i.MX6 UL VAR-SOM SDCARD/NAND + WM8904";

--- a/arch/arm/boot/dts/imx6ull-var-som-5g-emmc_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-5g-emmc_wifi-wm8731.dts
@@ -15,5 +15,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
 
 / {
-        model = "Variscite i.MX6 ULL VAR-SOM-5G eMMC + WM8731";
+        model = "Variscite i.MX6 ULL VAR-SOM-5G eMMC + WM8731 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ull-var-som-5g-emmc_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-5g-emmc_wifi-wm8731.dts
@@ -12,7 +12,7 @@
 /* #define  NAND */
 #define PHY
 #include "imx6ull-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8731.dtsi"
 
 / {
         model = "Variscite i.MX6 ULL VAR-SOM-5G eMMC + WM8731 + WIFI";

--- a/arch/arm/boot/dts/imx6ull-var-som-5g-emmc_wifi.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-5g-emmc_wifi.dts
@@ -15,5 +15,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
 
 / {
-        model = "Variscite i.MX6 ULL VAR-SOM-5G eMMC + WM8904";
+        model = "Variscite i.MX6 ULL VAR-SOM-5G eMMC + WM8904 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ull-var-som-5g-emmc_wifi.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-5g-emmc_wifi.dts
@@ -12,7 +12,7 @@
 /* #define  NAND */
 #define PHY
 #include "imx6ull-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8904.dtsi"
 
 / {
         model = "Variscite i.MX6 ULL VAR-SOM-5G eMMC + WM8904 + WIFI";

--- a/arch/arm/boot/dts/imx6ull-var-som-5g-nand_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-5g-nand_wifi-wm8731.dts
@@ -15,5 +15,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
 
 / {
-        model = "Variscite i.MX6 ULL VAR-SOM-5G NAND + WM8731";
+        model = "Variscite i.MX6 ULL VAR-SOM-5G NAND + WM8731 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ull-var-som-5g-nand_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-5g-nand_wifi-wm8731.dts
@@ -12,7 +12,7 @@
 #define  NAND
 #define PHY
 #include "imx6ull-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8731.dtsi"
 
 / {
         model = "Variscite i.MX6 ULL VAR-SOM-5G NAND + WM8731 + WIFI";

--- a/arch/arm/boot/dts/imx6ull-var-som-5g-nand_wifi.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-5g-nand_wifi.dts
@@ -12,7 +12,7 @@
 #define  NAND
 #define PHY
 #include "imx6ull-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8904.dtsi"
 
 / {
         model = "Variscite i.MX6 ULL VAR-SOM-5G NAND + WM8904 + WIFI";

--- a/arch/arm/boot/dts/imx6ull-var-som-5g-nand_wifi.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-5g-nand_wifi.dts
@@ -15,5 +15,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
 
 / {
-        model = "Variscite i.MX6 ULL VAR-SOM-5G NAND + WM8904";
+        model = "Variscite i.MX6 ULL VAR-SOM-5G NAND + WM8904 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ull-var-som-emmc_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-emmc_wifi-wm8731.dts
@@ -14,5 +14,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
 
 / {
-        model = "Variscite i.MX6 ULL VAR-SOM eMMC + WM8731";
+        model = "Variscite i.MX6 ULL VAR-SOM eMMC + WM8731 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ull-var-som-emmc_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-emmc_wifi-wm8731.dts
@@ -11,7 +11,7 @@
 /* #define  NAND */
 #define PHY
 #include "imx6ull-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8731.dtsi"
 
 / {
         model = "Variscite i.MX6 ULL VAR-SOM eMMC + WM8731 + WIFI";

--- a/arch/arm/boot/dts/imx6ull-var-som-emmc_wifi.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-emmc_wifi.dts
@@ -11,7 +11,7 @@
 /* #define  NAND */
 #define PHY
 #include "imx6ull-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8904.dtsi"
 
 / {
         model = "Variscite i.MX6 ULL VAR-SOM eMMC + WM8904 + WIFI";

--- a/arch/arm/boot/dts/imx6ull-var-som-emmc_wifi.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-emmc_wifi.dts
@@ -14,5 +14,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
 
 / {
-        model = "Variscite i.MX6 ULL VAR-SOM eMMC + WM8904";
+        model = "Variscite i.MX6 ULL VAR-SOM eMMC + WM8904 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ull-var-som-nand_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-nand_wifi-wm8731.dts
@@ -11,7 +11,7 @@
 #define  NAND
 #define PHY
 #include "imx6ull-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8731.dtsi"
 
 / {
         model = "Variscite i.MX6 ULL VAR-SOM NAND + WM8731 + WIFI";

--- a/arch/arm/boot/dts/imx6ull-var-som-nand_wifi-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-nand_wifi-wm8731.dts
@@ -14,5 +14,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
 
 / {
-        model = "Variscite i.MX6 ULL VAR-SOM NAND + WM8731";
+        model = "Variscite i.MX6 ULL VAR-SOM NAND + WM8731 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ull-var-som-nand_wifi.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-nand_wifi.dts
@@ -11,7 +11,7 @@
 #define  NAND
 #define PHY
 #include "imx6ull-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8904.dtsi"
 
 / {
         model = "Variscite i.MX6 ULL VAR-SOM NAND + WM8904 + WIFI";

--- a/arch/arm/boot/dts/imx6ull-var-som-nand_wifi.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-nand_wifi.dts
@@ -14,5 +14,5 @@
 #include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
 
 / {
-        model = "Variscite i.MX6 ULL VAR-SOM NAND + WM8904";
+        model = "Variscite i.MX6 ULL VAR-SOM NAND + WM8904 + WIFI";
 };

--- a/arch/arm/boot/dts/imx6ull-var-som-sd_emmc-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-sd_emmc-wm8731.dts
@@ -11,7 +11,7 @@
 /* #define  NAND */
 #define PHY
 #include "imx6ull-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8731.dtsi"
 
 / {
         model = "Variscite i.MX6 ULL VAR-SOM SDCARD/eMMC + WM8731";

--- a/arch/arm/boot/dts/imx6ull-var-som-sd_emmc.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-sd_emmc.dts
@@ -11,7 +11,7 @@
 /* #define  NAND */
 #define PHY
 #include "imx6ull-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8904.dtsi"
 
 / {
         model = "Variscite i.MX6 ULL VAR-SOM SDCARD/eMMC + WM8904";

--- a/arch/arm/boot/dts/imx6ull-var-som-sd_nand-wm8731.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-sd_nand-wm8731.dts
@@ -11,7 +11,7 @@
 #define  NAND
 #define PHY
 #include "imx6ull-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8731.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8731.dtsi"
 
 / {
         model = "Variscite i.MX6 ULL VAR-SOM SDCARD/NAND + WM8731";

--- a/arch/arm/boot/dts/imx6ull-var-som-sd_nand.dts
+++ b/arch/arm/boot/dts/imx6ull-var-som-sd_nand.dts
@@ -11,7 +11,7 @@
 #define  NAND
 #define PHY
 #include "imx6ull-var-som.dtsi"
-#include "imx6ul-imx6ull-var-dart-wm8904.dtsi"
+#include "imx6ul-imx6ull-var-som-wm8904.dtsi"
 
 / {
         model = "Variscite i.MX6 ULL VAR-SOM SDCARD/NAND + WM8904";


### PR DESCRIPTION
The wifi init script only runs if WIFI is found in the machine string: https://github.com/varjig/meta-variscite-imx-jig/blob/13491c9ac8955345cae82b6ce04625aab0d88167/recipes-connectivity/bcm43xx-utils/bcm43xx-utils/variscite-wifi#L48-L51

This patch adds WIFI to all model strings for machines that support wifi.